### PR TITLE
Added manual response to avoid leaking sendGrid response

### DIFF
--- a/pages/api/recordClearance.ts
+++ b/pages/api/recordClearance.ts
@@ -100,8 +100,13 @@ const recordClearance = async (
         )}; Max-Age=${oneWeekInSeconds}; Path=/; HttpOnly; Secure; SameSite=Strict`,
       )
     }
-
-    res.json({ ...sendMsg })
+    // Returning a stripped down version of the sendGrid response
+    // with only statusCode, instead of the whole thing
+    res.json({
+      0: {
+        statusCode: sgResponse.statusCode,
+      },
+    })
   } catch (error) {
     console.error(error)
     if (error instanceof ValidationError) {


### PR DESCRIPTION
Created a simple response object with only the sendgrid response status code to avoid leaking any information. 
Object has the same properties and nesting as the sendgrid response because ExpungementForm component relies on that format.