### PR TITLE
Fixed error responding with an object

### DIFF
--- a/pages/api/recordClearance.ts
+++ b/pages/api/recordClearance.ts
@@ -107,9 +107,10 @@ const recordClearance = async (
         statusCode: sgResponse.statusCode,
       },
     })
-  } catch (error) {
+  } catch (err) {
+    const error: string = err.message
     console.error(error)
-    if (error instanceof ValidationError) {
+    if (err instanceof ValidationError) {
       res.json({ error })
     } else {
       res.json({ error: 'An error has occurred.' })


### PR DESCRIPTION
Fixed bug in recordClearance API where error response was sending the error object instead of the error message